### PR TITLE
Release 2.0.2

### DIFF
--- a/SimStackServer/ClusterManager.py
+++ b/SimStackServer/ClusterManager.py
@@ -655,7 +655,12 @@ class ClusterManager:
     def get_url_for_workflow(self, workflow):
         if not workflow.startswith("/"):
             workflow = "/%s" % workflow
-        return f"{self.get_client_url()}/http/browse{workflow}"
+        if self._use_ssh_tunnel and self._ssh_tunnel is not None:
+            local_port = self._ssh_tunnel.local_bind_port
+            base_url = f"https://127.0.0.1:{local_port}"
+        else:
+            base_url = self.get_client_url()
+        return f"{base_url}/http/browse{workflow}"
 
     def submit_wf(self, filename, basepath_override=None):
         """Submit a workflow using REST API"""

--- a/SimStackServer/__init__.py
+++ b/SimStackServer/__init__.py
@@ -2,4 +2,4 @@
   SimStackServer
   Please read the docs found at: https://simstack.readthedocs.io/
 """
-__version__ = "2.0.1"
+__version__ = "2.0.2"

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: simstackserver
-  version: "2.0.1"
+  version: "2.0.2"
 about:
   home: https://github.com/NanomatchGmbH/simstackserver
   license: proprietary

--- a/pixi.lock
+++ b/pixi.lock
@@ -3544,8 +3544,8 @@ packages:
   timestamp: 1766034103379
 - pypi: ./
   name: simstackserver
-  version: 2.0.1
-  sha256: 40ddd0c2fd79df863fbce8c3c055d808f64cc46547256fb9f90569237fffdd41
+  version: 2.0.2
+  sha256: 05a7aef2438624e56370b2b0ec81378f3992acd16781064d412e9b6224aa6502
   requires_python: '>=3.11'
   editable: true
 - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ dependencies = []
 readme = "README.md"
 license = {file = "LICENSE"}
 classifiers = ["License :: OSI Approved :: MIT License"]
-version="2.0.1"
+version="2.0.2"
 description="Server Component of the SimStack workflow system"
 
 [project.urls]

--- a/tests/test_ClusterManager.py
+++ b/tests/test_ClusterManager.py
@@ -1007,3 +1007,33 @@ def test_direct_connection_context(direct_cluster_manager, respx_mock):
             assert result is None
             mock_init.assert_called_once()
         mock_disconnect.assert_called_once()
+
+
+def test_get_url_for_workflow_direct(direct_cluster_manager):
+    """Without SSH tunnel, get_url_for_workflow uses the remote host URL."""
+    url = direct_cluster_manager.get_url_for_workflow("my_workflow")
+    assert url == "https://fake-url:8443/http/browse/my_workflow"
+
+
+def test_get_url_for_workflow_direct_leading_slash(direct_cluster_manager):
+    """Leading slash in workflow name is not doubled."""
+    url = direct_cluster_manager.get_url_for_workflow("/my_workflow")
+    assert url == "https://fake-url:8443/http/browse/my_workflow"
+
+
+def test_get_url_for_workflow_ssh_tunnel(cluster_manager):
+    """With SSH tunnel active, get_url_for_workflow uses localhost and the local bind port."""
+    mock_tunnel = MagicMock()
+    mock_tunnel.local_bind_port = 54321
+    cluster_manager._ssh_tunnel = mock_tunnel
+
+    url = cluster_manager.get_url_for_workflow("my_workflow")
+    assert url == "https://127.0.0.1:54321/http/browse/my_workflow"
+
+
+def test_get_url_for_workflow_ssh_tunnel_not_started(cluster_manager):
+    """With use_ssh_tunnel=True but tunnel not yet started, falls back to remote URL."""
+    cluster_manager._ssh_tunnel = None
+
+    url = cluster_manager.get_url_for_workflow("my_workflow")
+    assert url == "https://fake-url:80/http/browse/my_workflow"


### PR DESCRIPTION
HTTP Browse was still broken in the ssh tunnel -> REST case.

## Type of Change

<!-- Please check the relevant option(s) -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement

## Changes Made

<!-- Describe the specific changes made in this PR -->

-
-
-

## Related Issues

<!-- Link to related issues using "Fixes #123" or "Closes #123" -->

Fixes #
Related to #
